### PR TITLE
feat(*): implement upgrade

### DIFF
--- a/cmd/helm/main.go
+++ b/cmd/helm/main.go
@@ -37,6 +37,7 @@ func buildRootCommand(in io.Reader) *cobra.Command {
 	cmd.AddCommand(buildBuildCommand(m))
 	cmd.AddCommand(buildInstallCommand(m))
 	cmd.AddCommand(buildUninstallCommand(m))
+	cmd.AddCommand(buildUpgradeCommand(m))
 
 	return cmd
 }

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"github.com/deislabs/porter-helm/pkg/helm"
+	"github.com/spf13/cobra"
+)
+
+func buildUpgradeCommand(m *helm.Mixin) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "upgrade",
+		Short: "Execute the upgrade functionality of this mixin",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return m.Upgrade()
+		},
+	}
+	return cmd
+}

--- a/pkg/helm/upgrade.go
+++ b/pkg/helm/upgrade.go
@@ -1,0 +1,104 @@
+package helm
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
+)
+
+// UpgradeStep represents the structure of an Upgrade step
+type UpgradeStep struct {
+	Description string           `yaml:"description"`
+	Outputs     []HelmOutput     `yaml:"outputs"`
+	Arguments   UpgradeArguments `yaml:"helm"`
+}
+
+// UpgradeArguments represent the arguments available to the Upgrade step
+type UpgradeArguments struct {
+	Namespace string            `yaml:"namespace"`
+	Name      string            `yaml:"name"`
+	Chart     string            `yaml:"chart"`
+	Version   string            `yaml:"version"`
+	Replace   bool              `yaml:"replace"`
+	Set       map[string]string `yaml:"set"`
+	Values    []string          `yaml:"values"`
+}
+
+// Upgrade issues a helm upgrade command for a release using the provided UpgradeArguments
+func (m *Mixin) Upgrade() error {
+	payload, err := m.getPayloadData()
+	if err != nil {
+		return err
+	}
+
+	kubeClient, err := m.getKubernetesClient("/root/.kube/config")
+	if err != nil {
+		return errors.Wrap(err, "couldn't get kubernetes client")
+	}
+
+	var step UpgradeStep
+	err = yaml.Unmarshal(payload, &step)
+	if err != nil {
+		return err
+	}
+
+	cmd := m.NewCommand("helm", "upgrade", step.Arguments.Name, step.Arguments.Chart)
+
+	if step.Arguments.Namespace != "" {
+		cmd.Args = append(cmd.Args, "--namespace", step.Arguments.Namespace)
+	}
+
+	if step.Arguments.Version != "" {
+		cmd.Args = append(cmd.Args, "--version", step.Arguments.Version)
+	}
+
+	if step.Arguments.Replace {
+		cmd.Args = append(cmd.Args, "--replace")
+	}
+
+	for _, v := range step.Arguments.Values {
+		cmd.Args = append(cmd.Args, "--values", v)
+	}
+
+	// sort the set consistently
+	setKeys := make([]string, 0, len(step.Arguments.Set))
+	for k := range step.Arguments.Set {
+		setKeys = append(setKeys, k)
+	}
+	sort.Strings(setKeys)
+
+	for _, k := range setKeys {
+		cmd.Args = append(cmd.Args, "--set", fmt.Sprintf("%s=%s", k, step.Arguments.Set[k]))
+	}
+
+	cmd.Stdout = m.Out
+	cmd.Stderr = m.Err
+
+	prettyCmd := fmt.Sprintf("%s %s", cmd.Path, strings.Join(cmd.Args, " "))
+	fmt.Fprintln(m.Out, prettyCmd)
+
+	err = cmd.Start()
+	if err != nil {
+		return fmt.Errorf("could not execute command, %s: %s", prettyCmd, err)
+	}
+	err = cmd.Wait()
+	if err != nil {
+		return err
+	}
+
+	var lines []string
+	for _, output := range step.Outputs {
+		val, err := getSecret(kubeClient, step.Arguments.Namespace, output.Secret, output.Key)
+		if err != nil {
+			return err
+		}
+		l := fmt.Sprintf("%s=%s", output.Name, val)
+		lines = append(lines, l)
+
+	}
+	m.Context.WriteOutput(lines)
+	return nil
+}

--- a/pkg/helm/upgrade_test.go
+++ b/pkg/helm/upgrade_test.go
@@ -1,0 +1,42 @@
+package helm
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/deislabs/porter/pkg/test"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+func TestMixin_Upgrade(t *testing.T) {
+	os.Setenv(test.ExpectedCommandEnv, `helm upgrade MYRELEASE MYCHART --namespace MYNAMESPACE --version 1.0.0 --replace --values /tmp/val1.yaml --values /tmp/val2.yaml --set baz=qux --set foo=bar`)
+	defer os.Unsetenv(test.ExpectedCommandEnv)
+
+	step := UpgradeStep{
+		Arguments: UpgradeArguments{
+			Namespace: "MYNAMESPACE",
+			Name:      "MYRELEASE",
+			Chart:     "MYCHART",
+			Version:   "1.0.0",
+			Replace:   true,
+			Set: map[string]string{
+				"foo": "bar",
+				"baz": "qux",
+			},
+			Values: []string{
+				"/tmp/val1.yaml",
+				"/tmp/val2.yaml",
+			},
+		},
+	}
+	b, _ := yaml.Marshal(step)
+
+	h := NewTestMixin(t)
+	h.In = bytes.NewReader(b)
+
+	err := h.Upgrade()
+
+	require.NoError(t, err)
+}


### PR DESCRIPTION
This represents the naive/mostly-copy-paste implementation.  

As you'll note, `upgrade.go` looks nearly identical to the pre-existing `install.go`, just with a slightly different cmd base.  We could extract shared logic into a new file that both could use (`upsert.go`?) which has a cmd base of `helm upgrade`, with, conditionally, `--install`, depending on caller (`install.go` vs `upgrade.go`).  Should we go this route here?  And/or a diff approach?