### PR TITLE
feat(install.go): add wait flag

### DIFF
--- a/pkg/helm/install.go
+++ b/pkg/helm/install.go
@@ -29,6 +29,7 @@ type InstallArguments struct {
 	Replace   bool              `yaml:"replace"`
 	Set       map[string]string `yaml:"set"`
 	Values    []string          `yaml:"values"`
+	Wait      bool              `yaml:"wait"`
 }
 
 func (m *Mixin) Install() error {
@@ -60,6 +61,10 @@ func (m *Mixin) Install() error {
 
 	if step.Arguments.Replace {
 		cmd.Args = append(cmd.Args, "--replace")
+	}
+
+	if step.Arguments.Wait {
+		cmd.Args = append(cmd.Args, "--wait")
 	}
 
 	for _, v := range step.Arguments.Values {

--- a/pkg/helm/install_test.go
+++ b/pkg/helm/install_test.go
@@ -2,6 +2,7 @@ package helm
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"testing"
 
@@ -10,38 +11,89 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+type InstallTest struct {
+	expectedCommand string
+	installStep     InstallStep
+}
+
 // sad hack: not sure how to make a common test main for all my subpackages
 func TestMain(m *testing.M) {
 	test.TestMainWithMockedCommandHandlers(m)
 }
 
 func TestMixin_Install(t *testing.T) {
-	os.Setenv(test.ExpectedCommandEnv, `helm install --name MYRELEASE MYCHART --namespace MYNAMESPACE --version 1.0.0 --replace --values /tmp/val1.yaml --values /tmp/val2.yaml --set baz=qux --set foo=bar`)
-	defer os.Unsetenv(test.ExpectedCommandEnv)
+	namespace := "MYNAMESPACE"
+	name := "MYRELEASE"
+	chart := "MYCHART"
+	version := "1.0.0"
+	setArgs := map[string]string{
+		"foo": "bar",
+		"baz": "qux",
+	}
+	values := []string{
+		"/tmp/val1.yaml",
+		"/tmp/val2.yaml",
+	}
 
-	step := InstallStep{
-		Arguments: InstallArguments{
-			Namespace: "MYNAMESPACE",
-			Name:      "MYRELEASE",
-			Chart:     "MYCHART",
-			Version:   "1.0.0",
-			Replace:   true,
-			Set: map[string]string{
-				"foo": "bar",
-				"baz": "qux",
+	baseInstall := fmt.Sprintf(`helm install --name %s %s --namespace %s --version %s`, name, chart, namespace, version)
+	baseValues := `--values /tmp/val1.yaml --values /tmp/val2.yaml`
+	baseSetArgs := `--set baz=qux --set foo=bar`
+
+	installTests := []InstallTest{
+		InstallTest{
+			expectedCommand: fmt.Sprintf(`%s %s %s`, baseInstall, baseValues, baseSetArgs),
+			installStep: InstallStep{
+				Arguments: InstallArguments{
+					Namespace: namespace,
+					Name:      name,
+					Chart:     chart,
+					Version:   version,
+					Set:       setArgs,
+					Values:    values,
+				},
 			},
-			Values: []string{
-				"/tmp/val1.yaml",
-				"/tmp/val2.yaml",
+		},
+		InstallTest{
+			expectedCommand: fmt.Sprintf(`%s %s %s %s`, baseInstall, `--replace`, baseValues, baseSetArgs),
+			installStep: InstallStep{
+				Arguments: InstallArguments{
+					Namespace: namespace,
+					Name:      name,
+					Chart:     chart,
+					Version:   version,
+					Set:       setArgs,
+					Values:    values,
+					Replace:   true,
+				},
+			},
+		},
+		InstallTest{
+			expectedCommand: fmt.Sprintf(`%s %s %s %s`, baseInstall, `--wait`, baseValues, baseSetArgs),
+			installStep: InstallStep{
+				Arguments: InstallArguments{
+					Namespace: namespace,
+					Name:      name,
+					Chart:     chart,
+					Version:   version,
+					Set:       setArgs,
+					Values:    values,
+					Wait:      true,
+				},
 			},
 		},
 	}
-	b, _ := yaml.Marshal(step)
 
-	h := NewTestMixin(t)
-	h.In = bytes.NewReader(b)
+	for _, installTest := range installTests {
+		os.Setenv(test.ExpectedCommandEnv, installTest.expectedCommand)
+		defer os.Unsetenv(test.ExpectedCommandEnv)
 
-	err := h.Install()
+		b, _ := yaml.Marshal(installTest.installStep)
 
-	require.NoError(t, err)
+		h := NewTestMixin(t)
+		h.In = bytes.NewReader(b)
+
+		err := h.Install()
+
+		require.NoError(t, err)
+	}
 }


### PR DESCRIPTION
Adds ability to set `--wait` on the `helm install` command.  See docs in https://github.com/helm/helm/blob/master/docs/helm/helm_install.md