### PR TITLE
feat(upgrade): remove invalid replace flag, add further flags

### DIFF
--- a/pkg/helm/upgrade.go
+++ b/pkg/helm/upgrade.go
@@ -18,13 +18,15 @@ type UpgradeStep struct {
 
 // UpgradeArguments represent the arguments available to the Upgrade step
 type UpgradeArguments struct {
-	Namespace string            `yaml:"namespace"`
-	Name      string            `yaml:"name"`
-	Chart     string            `yaml:"chart"`
-	Version   string            `yaml:"version"`
-	Replace   bool              `yaml:"replace"`
-	Set       map[string]string `yaml:"set"`
-	Values    []string          `yaml:"values"`
+	Namespace   string            `yaml:"namespace"`
+	Name        string            `yaml:"name"`
+	Chart       string            `yaml:"chart"`
+	Version     string            `yaml:"version"`
+	Set         map[string]string `yaml:"set"`
+	Values      []string          `yaml:"values"`
+	Wait        bool              `yaml:"wait"`
+	ResetValues bool              `yaml:"resetValues"`
+	ReuseValues bool              `yaml:"reuseValues"`
 }
 
 // Upgrade issues a helm upgrade command for a release using the provided UpgradeArguments
@@ -55,8 +57,16 @@ func (m *Mixin) Upgrade() error {
 		cmd.Args = append(cmd.Args, "--version", step.Arguments.Version)
 	}
 
-	if step.Arguments.Replace {
-		cmd.Args = append(cmd.Args, "--replace")
+	if step.Arguments.ResetValues {
+		cmd.Args = append(cmd.Args, "--reset-values")
+	}
+
+	if step.Arguments.ReuseValues {
+		cmd.Args = append(cmd.Args, "--reuse-values")
+	}
+
+	if step.Arguments.Wait {
+		cmd.Args = append(cmd.Args, "--wait")
 	}
 
 	for _, v := range step.Arguments.Values {

--- a/pkg/helm/upgrade_test.go
+++ b/pkg/helm/upgrade_test.go
@@ -96,12 +96,13 @@ func TestMixin_Upgrade(t *testing.T) {
 		os.Setenv(test.ExpectedCommandEnv, upgradeTest.expectedCommand)
 		defer os.Unsetenv(test.ExpectedCommandEnv)
 
-		b, _ := yaml.Marshal(upgradeTest.upgradeStep)
+		b, err := yaml.Marshal(upgradeTest.upgradeStep)
+		require.NoError(t, err)
 
 		h := NewTestMixin(t)
 		h.In = bytes.NewReader(b)
 
-		err := h.Upgrade()
+		err = h.Upgrade()
 
 		require.NoError(t, err)
 	}


### PR DESCRIPTION
- Removes invalid `replace` flag from the upgrade action
- Adds `reuse-values`, `reset-values` and `wait` flags
- Refactors the upgrade test to support varying flag options

I still hope to refactor/consolidate similar logic between install and upgrade, but wanted to get this PR up while testing upgrade in porter.