### PR TITLE
Rearrange schema

### DIFF
--- a/pkg/helm/install_test.go
+++ b/pkg/helm/install_test.go
@@ -83,17 +83,19 @@ func TestMixin_Install(t *testing.T) {
 		},
 	}
 
+	defer os.Unsetenv(test.ExpectedCommandEnv)
 	for _, installTest := range installTests {
-		os.Setenv(test.ExpectedCommandEnv, installTest.expectedCommand)
-		defer os.Unsetenv(test.ExpectedCommandEnv)
+		t.Run(installTest.expectedCommand, func(t *testing.T) {
+			os.Setenv(test.ExpectedCommandEnv, installTest.expectedCommand)
 
-		b, _ := yaml.Marshal(installTest.installStep)
+			b, _ := yaml.Marshal(installTest.installStep)
 
-		h := NewTestMixin(t)
-		h.In = bytes.NewReader(b)
+			h := NewTestMixin(t)
+			h.In = bytes.NewReader(b)
 
-		err := h.Install()
+			err := h.Install()
 
-		require.NoError(t, err)
+			require.NoError(t, err)
+		})
 	}
 }

--- a/pkg/helm/install_test.go
+++ b/pkg/helm/install_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/deislabs/porter/pkg/test"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 type InstallTest struct {
@@ -40,10 +40,10 @@ func TestMixin_Install(t *testing.T) {
 	baseSetArgs := `--set baz=qux --set foo=bar`
 
 	installTests := []InstallTest{
-		InstallTest{
+		{
 			expectedCommand: fmt.Sprintf(`%s %s %s`, baseInstall, baseValues, baseSetArgs),
 			installStep: InstallStep{
-				Arguments: InstallArguments{
+				InstallArguments: InstallArguments{
 					Namespace: namespace,
 					Name:      name,
 					Chart:     chart,
@@ -53,10 +53,10 @@ func TestMixin_Install(t *testing.T) {
 				},
 			},
 		},
-		InstallTest{
+		{
 			expectedCommand: fmt.Sprintf(`%s %s %s %s`, baseInstall, `--replace`, baseValues, baseSetArgs),
 			installStep: InstallStep{
-				Arguments: InstallArguments{
+				InstallArguments: InstallArguments{
 					Namespace: namespace,
 					Name:      name,
 					Chart:     chart,
@@ -67,10 +67,10 @@ func TestMixin_Install(t *testing.T) {
 				},
 			},
 		},
-		InstallTest{
+		{
 			expectedCommand: fmt.Sprintf(`%s %s %s %s`, baseInstall, `--wait`, baseValues, baseSetArgs),
 			installStep: InstallStep{
-				Arguments: InstallArguments{
+				InstallArguments: InstallArguments{
 					Namespace: namespace,
 					Name:      name,
 					Chart:     chart,

--- a/pkg/helm/packrd/packed-packr.go
+++ b/pkg/helm/packrd/packed-packr.go
@@ -10,10 +10,10 @@ import (
 )
 
 var _ = func() error {
-	const gk = "e8b612f3d3cebcbb08d7e57bbe5a8784"
+	const gk = "0642184c5beeead54427e1fe43a3f941"
 	g := packr.New(gk, "")
 	hgr, err := resolver.NewHexGzip(map[string]string{
-		"d9a4c1f2321237a9e233807ce352b839": "1f8b08000000000000ff8cce4b0ec2300c04d07d4e61cdba27e829b882692d300a49e40c0b847a7754f151965d8e3d4f9a571281974ecd19b3ec51047c36c32ca8e79b2dc4f4b9b6a8cd826efddf1441d1bb0d79d09de1e582ef639b7e62b96af010490384aeabd36bd17c1a87301e96f6ee96de010000ffff59af4438cd000000",
+		"ceb28a170ec6b83313fa217d1e4bffdf": "1f8b08000000000000ff8cce4b0ec2300c04d07d4e61cdba27e829b882692d300a49e40c0b847a7754f151965d8e3d4f9a571281974ecd19b3ec51047c36c32ca8e79b2dc4f4b9b6a8cd826efddf1441d1bb0d79d09de1e582ef639b7e62b96af010490384aeabd36bd17c1a87301e96f6ee96de010000ffff59af4438cd000000",
 	})
 	if err != nil {
 		panic(err)
@@ -22,7 +22,7 @@ var _ = func() error {
 
 	func() {
 		b := packr.New("schema", "./schema")
-		b.SetResolver("mixin.json", packr.Pointer{ForwardBox: gk, ForwardPath: "d9a4c1f2321237a9e233807ce352b839"})
+		b.SetResolver("mixin.json", packr.Pointer{ForwardBox: gk, ForwardPath: "ceb28a170ec6b83313fa217d1e4bffdf"})
 	}()
 
 	return nil

--- a/pkg/helm/status.go
+++ b/pkg/helm/status.go
@@ -4,19 +4,19 @@ import (
 	"fmt"
 	"strings"
 
-	"gopkg.in/yaml.v2"
-
 	"github.com/deislabs/porter/pkg/printer"
+	yaml "gopkg.in/yaml.v2"
 )
 
 // StatusStep represents the structure of an Status action
 type StatusStep struct {
-	Description string          `yaml:"description"`
-	Arguments   StatusArguments `yaml:"helm"`
+	StatusArguments `yaml:"helm"`
 }
 
 // StatusArguments are the arguments available for the Status action
 type StatusArguments struct {
+	Step `yaml:,inline`
+
 	Releases []string `yaml:"releases"`
 }
 
@@ -45,7 +45,7 @@ func (m *Mixin) Status(opts printer.PrintOptions) error {
 		return fmt.Errorf("invalid format: %s", opts.Format)
 	}
 
-	for _, release := range step.Arguments.Releases {
+	for _, release := range step.Releases {
 		cmd := m.NewCommand("helm", "status", strings.TrimSpace(fmt.Sprintf(`%s %s`, release, format)))
 
 		cmd.Stdout = m.Out

--- a/pkg/helm/status_test.go
+++ b/pkg/helm/status_test.go
@@ -39,27 +39,29 @@ func TestMixin_Status(t *testing.T) {
 		"bar",
 	}
 
-	for _, testCase := range testCases {
+	defer os.Unsetenv(test.ExpectedCommandEnv)
+	for testName, testCase := range testCases {
 		for _, release := range releases {
-			os.Setenv(test.ExpectedCommandEnv,
-				strings.TrimSpace(fmt.Sprintf(`helm status %s %s`, release, testCase.expectedCommandSuffix)))
-			defer os.Unsetenv(test.ExpectedCommandEnv)
+			t.Run(testName, func(t *testing.T) {
+				os.Setenv(test.ExpectedCommandEnv,
+					strings.TrimSpace(fmt.Sprintf(`helm status %s %s`, release, testCase.expectedCommandSuffix)))
 
-			statusStep := StatusStep{
-				Arguments: StatusArguments{
-					Releases: []string{release},
-				},
-			}
+				statusStep := StatusStep{
+					StatusArguments: StatusArguments{
+						Releases: []string{release},
+					},
+				}
 
-			b, _ := yaml.Marshal(statusStep)
+				b, _ := yaml.Marshal(statusStep)
 
-			h := NewTestMixin(t)
-			h.In = bytes.NewReader(b)
+				h := NewTestMixin(t)
+				h.In = bytes.NewReader(b)
 
-			opts := printer.PrintOptions{testCase.format}
-			err := h.Status(opts)
+				opts := printer.PrintOptions{testCase.format}
+				err := h.Status(opts)
 
-			require.NoError(t, err)
+				require.NoError(t, err)
+			})
 		}
 	}
 }

--- a/pkg/helm/status_test.go
+++ b/pkg/helm/status_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/deislabs/porter/pkg/printer"
 	"github.com/deislabs/porter/pkg/test"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 type statusTest struct {
@@ -20,15 +20,15 @@ type statusTest struct {
 
 func TestMixin_Status(t *testing.T) {
 	testCases := map[string]statusTest{
-		"default": statusTest{
+		"default": {
 			format:                printer.FormatPlaintext,
 			expectedCommandSuffix: "",
 		},
-		"json": statusTest{
+		"json": {
 			format:                printer.FormatJson,
 			expectedCommandSuffix: "-o json",
 		},
-		"yaml": statusTest{
+		"yaml": {
 			format:                printer.FormatYaml,
 			expectedCommandSuffix: "-o yaml",
 		},

--- a/pkg/helm/step.go
+++ b/pkg/helm/step.go
@@ -1,0 +1,12 @@
+package helm
+
+type Step struct {
+	Description string       `yaml:"description"`
+	Outputs     []HelmOutput `yaml:"outputs"`
+}
+
+type HelmOutput struct {
+	Name   string `yaml:"name"`
+	Secret string `yaml:"secret"`
+	Key    string `yaml:"key"`
+}

--- a/pkg/helm/uninstall.go
+++ b/pkg/helm/uninstall.go
@@ -4,17 +4,18 @@ import (
 	"fmt"
 	"strings"
 
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 // UninstallStep represents the structure of an Uninstall action
 type UninstallStep struct {
-	Description string             `yaml:"description"`
-	Arguments   UninstallArguments `yaml:"helm"`
+	UninstallArguments `yaml:"helm"`
 }
 
 // UninstallArguments are the arguments available for the Uninstall action
 type UninstallArguments struct {
+	Step `yaml:,inline`
+
 	Releases []string `yaml:"releases"`
 	Purge    bool     `yaml:"purge"`
 }
@@ -34,11 +35,11 @@ func (m *Mixin) Uninstall() error {
 
 	cmd := m.NewCommand("helm", "delete")
 
-	if step.Arguments.Purge {
+	if step.Purge {
 		cmd.Args = append(cmd.Args, "--purge")
 	}
 
-	for _, release := range step.Arguments.Releases {
+	for _, release := range step.Releases {
 		cmd.Args = append(cmd.Args, release)
 	}
 

--- a/pkg/helm/uninstall_test.go
+++ b/pkg/helm/uninstall_test.go
@@ -41,17 +41,19 @@ func TestMixin_Uninstall(t *testing.T) {
 		},
 	}
 
+	defer os.Unsetenv(test.ExpectedCommandEnv)
 	for _, uninstallTest := range uninstallTests {
-		os.Setenv(test.ExpectedCommandEnv, uninstallTest.expectedCommand)
-		defer os.Unsetenv(test.ExpectedCommandEnv)
+		t.Run(uninstallTest.expectedCommand, func(t *testing.T) {
+			os.Setenv(test.ExpectedCommandEnv, uninstallTest.expectedCommand)
 
-		b, _ := yaml.Marshal(uninstallTest.uninstallStep)
+			b, _ := yaml.Marshal(uninstallTest.uninstallStep)
 
-		h := NewTestMixin(t)
-		h.In = bytes.NewReader(b)
+			h := NewTestMixin(t)
+			h.In = bytes.NewReader(b)
 
-		err := h.Uninstall()
+			err := h.Uninstall()
 
-		require.NoError(t, err)
+			require.NoError(t, err)
+		})
 	}
 }

--- a/pkg/helm/uninstall_test.go
+++ b/pkg/helm/uninstall_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/deislabs/porter/pkg/test"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 type UninstallTest struct {
@@ -22,18 +22,18 @@ func TestMixin_Uninstall(t *testing.T) {
 	}
 
 	uninstallTests := []UninstallTest{
-		UninstallTest{
+		{
 			expectedCommand: `helm delete foo bar`,
 			uninstallStep: UninstallStep{
-				Arguments: UninstallArguments{
+				UninstallArguments: UninstallArguments{
 					Releases: releases,
 				},
 			},
 		},
-		UninstallTest{
+		{
 			expectedCommand: `helm delete --purge foo bar`,
 			uninstallStep: UninstallStep{
-				Arguments: UninstallArguments{
+				UninstallArguments: UninstallArguments{
 					Purge:    true,
 					Releases: releases,
 				},

--- a/pkg/helm/upgrade_test.go
+++ b/pkg/helm/upgrade_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/deislabs/porter/pkg/test"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 type UpgradeTest struct {
@@ -35,10 +35,10 @@ func TestMixin_Upgrade(t *testing.T) {
 	baseSetArgs := `--set baz=qux --set foo=bar`
 
 	upgradeTests := []UpgradeTest{
-		UpgradeTest{
+		{
 			expectedCommand: fmt.Sprintf(`%s %s %s`, baseUpgrade, baseValues, baseSetArgs),
 			upgradeStep: UpgradeStep{
-				Arguments: UpgradeArguments{
+				UpgradeArguments: UpgradeArguments{
 					Namespace: namespace,
 					Name:      name,
 					Chart:     chart,
@@ -48,10 +48,10 @@ func TestMixin_Upgrade(t *testing.T) {
 				},
 			},
 		},
-		UpgradeTest{
+		{
 			expectedCommand: fmt.Sprintf(`%s %s %s %s`, baseUpgrade, `--reset-values`, baseValues, baseSetArgs),
 			upgradeStep: UpgradeStep{
-				Arguments: UpgradeArguments{
+				UpgradeArguments: UpgradeArguments{
 					Namespace:   namespace,
 					Name:        name,
 					Chart:       chart,
@@ -62,10 +62,10 @@ func TestMixin_Upgrade(t *testing.T) {
 				},
 			},
 		},
-		UpgradeTest{
+		{
 			expectedCommand: fmt.Sprintf(`%s %s %s %s`, baseUpgrade, `--reuse-values`, baseValues, baseSetArgs),
 			upgradeStep: UpgradeStep{
-				Arguments: UpgradeArguments{
+				UpgradeArguments: UpgradeArguments{
 					Namespace:   namespace,
 					Name:        name,
 					Chart:       chart,
@@ -76,10 +76,10 @@ func TestMixin_Upgrade(t *testing.T) {
 				},
 			},
 		},
-		UpgradeTest{
+		{
 			expectedCommand: fmt.Sprintf(`%s %s %s %s`, baseUpgrade, `--wait`, baseValues, baseSetArgs),
 			upgradeStep: UpgradeStep{
-				Arguments: UpgradeArguments{
+				UpgradeArguments: UpgradeArguments{
 					Namespace: namespace,
 					Name:      name,
 					Chart:     chart,

--- a/pkg/helm/upgrade_test.go
+++ b/pkg/helm/upgrade_test.go
@@ -92,18 +92,20 @@ func TestMixin_Upgrade(t *testing.T) {
 		},
 	}
 
+	defer os.Unsetenv(test.ExpectedCommandEnv)
 	for _, upgradeTest := range upgradeTests {
-		os.Setenv(test.ExpectedCommandEnv, upgradeTest.expectedCommand)
-		defer os.Unsetenv(test.ExpectedCommandEnv)
+		t.Run(upgradeTest.expectedCommand, func(t *testing.T) {
 
-		b, err := yaml.Marshal(upgradeTest.upgradeStep)
-		require.NoError(t, err)
+			os.Setenv(test.ExpectedCommandEnv, upgradeTest.expectedCommand)
+			b, err := yaml.Marshal(upgradeTest.upgradeStep)
+			require.NoError(t, err)
 
-		h := NewTestMixin(t)
-		h.In = bytes.NewReader(b)
+			h := NewTestMixin(t)
+			h.In = bytes.NewReader(b)
 
-		err = h.Upgrade()
+			err = h.Upgrade()
 
-		require.NoError(t, err)
+			require.NoError(t, err)
+		})
 	}
 }


### PR DESCRIPTION
This updates the helm mixin to match the latest change in porter where all the properties related to a step go _under_ the mixin name. See https://github.com/deislabs/porter/pull/182 for all the details.