### PR TITLE
Use relative schema references

### DIFF
--- a/pkg/helm/schema/helm.json
+++ b/pkg/helm/schema/helm.json
@@ -1,6 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://schema.porter.sh/mixins/helm.json",
   "definitions": {
     "installStep": {
       "type": "object",
@@ -9,7 +8,7 @@
           "type": "object",
           "properties": {
             "description": {
-              "$ref": "http://schema.porter.sh/mixins/helm.json#/definitions/stepDescription"
+              "$ref": "#/definitions/stepDescription"
             },
             "name": {
               "type": "string"
@@ -42,7 +41,7 @@
               }
             },
             "outputs": {
-              "$ref": "http://schema.porter.sh/mixins/helm.json#/definitions/outputs"
+              "$ref": "#/definitions/outputs"
             }
           },
           "additionalProperties": false,
@@ -65,7 +64,7 @@
           "type": "object",
           "properties": {
             "description": {
-              "$ref": "http://schema.porter.sh/mixins/helm.json#/definitions/stepDescription"
+              "$ref": "#/definitions/stepDescription"
             },
             "name": {
               "type": "string"
@@ -104,7 +103,7 @@
               "default": false
             },
             "outputs": {
-              "$ref": "http://schema.porter.sh/mixins/helm.json#/definitions/outputs"
+              "$ref": "#/definitions/outputs"
             }
           },
           "additionalProperties": false,
@@ -126,7 +125,7 @@
           "type": "object",
           "properties": {
             "description": {
-              "$ref": "http://schema.porter.sh/mixins/helm.json#/definitions/stepDescription"
+              "$ref": "#/definitions/stepDescription"
             },
             "releases": {
               "type": "array",
@@ -154,7 +153,7 @@
           "type": "object",
           "properties": {
             "description": {
-              "$ref": "http://schema.porter.sh/mixins/helm.json#/definitions/stepDescription"
+              "$ref": "#/definitions/stepDescription"
             },
             "releases": {
               "type": "array",
@@ -208,25 +207,25 @@
     "install": {
       "type": "array",
       "items": {
-        "$ref": "http://schema.porter.sh/mixins/helm.json#/definitions/installStep"
+        "$ref": "#/definitions/installStep"
       }
     },
     "upgrade": {
       "type": "array",
       "items": {
-        "$ref": "http://schema.porter.sh/mixins/helm.json#/definitions/upgradeStep"
+        "$ref": "#/definitions/upgradeStep"
       }
     },
     "status": {
       "type": "array",
       "items": {
-        "$ref": "http://schema.porter.sh/mixins/helm.json#/definitions/statusStep"
+        "$ref": "#/definitions/statusStep"
       }
     },
     "uninstall": {
       "type": "array",
       "items": {
-        "$ref": "http://schema.porter.sh/mixins/helm.json#/definitions/uninstallStep"
+        "$ref": "#/definitions/uninstallStep"
       }
     }
   },

--- a/pkg/helm/testdata/schema.json
+++ b/pkg/helm/testdata/schema.json
@@ -1,6 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://schema.porter.sh/mixins/helm.json",
   "definitions": {
     "installStep": {
       "type": "object",
@@ -9,7 +8,7 @@
           "type": "object",
           "properties": {
             "description": {
-              "$ref": "http://schema.porter.sh/mixins/helm.json#/definitions/stepDescription"
+              "$ref": "#/definitions/stepDescription"
             },
             "name": {
               "type": "string"
@@ -42,7 +41,7 @@
               }
             },
             "outputs": {
-              "$ref": "http://schema.porter.sh/mixins/helm.json#/definitions/outputs"
+              "$ref": "#/definitions/outputs"
             }
           },
           "additionalProperties": false,
@@ -65,7 +64,7 @@
           "type": "object",
           "properties": {
             "description": {
-              "$ref": "http://schema.porter.sh/mixins/helm.json#/definitions/stepDescription"
+              "$ref": "#/definitions/stepDescription"
             },
             "name": {
               "type": "string"
@@ -104,7 +103,7 @@
               "default": false
             },
             "outputs": {
-              "$ref": "http://schema.porter.sh/mixins/helm.json#/definitions/outputs"
+              "$ref": "#/definitions/outputs"
             }
           },
           "additionalProperties": false,
@@ -126,7 +125,7 @@
           "type": "object",
           "properties": {
             "description": {
-              "$ref": "http://schema.porter.sh/mixins/helm.json#/definitions/stepDescription"
+              "$ref": "#/definitions/stepDescription"
             },
             "releases": {
               "type": "array",
@@ -154,7 +153,7 @@
           "type": "object",
           "properties": {
             "description": {
-              "$ref": "http://schema.porter.sh/mixins/helm.json#/definitions/stepDescription"
+              "$ref": "#/definitions/stepDescription"
             },
             "releases": {
               "type": "array",
@@ -208,25 +207,25 @@
     "install": {
       "type": "array",
       "items": {
-        "$ref": "http://schema.porter.sh/mixins/helm.json#/definitions/installStep"
+        "$ref": "#/definitions/installStep"
       }
     },
     "upgrade": {
       "type": "array",
       "items": {
-        "$ref": "http://schema.porter.sh/mixins/helm.json#/definitions/upgradeStep"
+        "$ref": "#/definitions/upgradeStep"
       }
     },
     "status": {
       "type": "array",
       "items": {
-        "$ref": "http://schema.porter.sh/mixins/helm.json#/definitions/statusStep"
+        "$ref": "#/definitions/statusStep"
       }
     },
     "uninstall": {
       "type": "array",
       "items": {
-        "$ref": "http://schema.porter.sh/mixins/helm.json#/definitions/uninstallStep"
+        "$ref": "#/definitions/uninstallStep"
       }
     }
   },


### PR DESCRIPTION
Porter will handle converting these when it merges the schema. The library used by VS Code doesn't handle ids properly.