### PR TITLE
chore(*): bump helm version

### DIFF
--- a/pkg/helm/build.go
+++ b/pkg/helm/build.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 )
 
-const helmClientVersion = "v2.12.3"
+const helmClientVersion = "v2.13.0"
 const dockerfileLines = `RUN apt-get update && \
  apt-get install -y curl && \
  curl -o helm.tgz https://storage.googleapis.com/kubernetes-helm/helm-%s-linux-amd64.tar.gz && \

--- a/pkg/helm/build_test.go
+++ b/pkg/helm/build_test.go
@@ -15,7 +15,7 @@ func TestMixin_Build(t *testing.T) {
 
 	wantOutput := `RUN apt-get update && \
  apt-get install -y curl && \
- curl -o helm.tgz https://storage.googleapis.com/kubernetes-helm/helm-v2.12.3-linux-amd64.tar.gz && \
+ curl -o helm.tgz https://storage.googleapis.com/kubernetes-helm/helm-v2.13.0-linux-amd64.tar.gz && \
  tar -xzf helm.tgz && \
  mv linux-amd64/helm /usr/local/bin && \
  rm helm.tgz


### PR DESCRIPTION
Bumps helm to the latest [v2.13.0](https://github.com/helm/helm/releases/tag/v2.13.0) release