### PR TITLE
allow override for runtime platform in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ BINDIR = bin/mixins/$(MIXIN)
 
 CLIENT_PLATFORM = $(shell go env GOOS)
 CLIENT_ARCH = $(shell go env GOARCH)
-RUNTIME_PLATFORM = linux
-RUNTIME_ARCH = amd64
+RUNTIME_PLATFORM ?= linux
+RUNTIME_ARCH ?= amd64
 SUPPORTED_CLIENT_PLATFORMS = linux darwin windows
 SUPPORTED_CLIENT_ARCHES = amd64 386
 


### PR DESCRIPTION
I need this for local testing on Mac in order to be able to do
```
RUNTIME_PLATFORM=darwin make install
```
and then a 
```
porter run --action=install
```
on a bundle that users the Helm mixin

see also https://github.com/deislabs/porter-azure/pull/15