### PR TITLE
Do not print helptext on runtime errors

### DIFF
--- a/cmd/helm/main.go
+++ b/cmd/helm/main.go
@@ -28,6 +28,7 @@ func buildRootCommand(in io.Reader) *cobra.Command {
 			m.Out = cmd.OutOrStdout()
 			m.Err = cmd.OutOrStderr()
 		},
+		SilenceUsage: true,
 	}
 
 	cmd.PersistentFlags().BoolVar(&m.Debug, "debug", false, "Enable debug logging")


### PR DESCRIPTION
Here's an example of why we want this:

```
Uninstall MySQL
Error: uninstall.0.helm: releases is required
	* uninstall.0.helm: Additional property name is not allowed
Usage:
  helm uninstall [flags]

Flags:
  -h, --help   help for uninstall

Global Flags:
      --debug   Enable debug logging

err: uninstall.0.helm: releases is required
	* uninstall.0.helm: Additional property name is not allowed
Error: mixin execution failed: exit status 1
```

The helptext should only be printed when the command was called incorrectly. Otherwise it's just noise. We have this turned on for other commands (like porter) but just never got around flipping the switch for this one too.