### PR TITLE
feat(*): support non-string set values

### DIFF
--- a/pkg/helm/install.go
+++ b/pkg/helm/install.go
@@ -20,14 +20,14 @@ type InstallStep struct {
 type InstallArguments struct {
 	Step `yaml:",inline"`
 
-	Namespace string            `yaml:"namespace"`
-	Name      string            `yaml:"name"`
-	Chart     string            `yaml:"chart"`
-	Version   string            `yaml:"version"`
-	Replace   bool              `yaml:"replace"`
-	Set       map[string]string `yaml:"set"`
-	Values    []string          `yaml:"values"`
-	Wait      bool              `yaml:"wait"`
+	Namespace string                 `yaml:"namespace"`
+	Name      string                 `yaml:"name"`
+	Chart     string                 `yaml:"chart"`
+	Version   string                 `yaml:"version"`
+	Replace   bool                   `yaml:"replace"`
+	Set       map[string]interface{} `yaml:"set"`
+	Values    []string               `yaml:"values"`
+	Wait      bool                   `yaml:"wait"`
 }
 
 func (m *Mixin) Install() error {
@@ -81,7 +81,7 @@ func (m *Mixin) Install() error {
 	sort.Strings(setKeys)
 
 	for _, k := range setKeys {
-		cmd.Args = append(cmd.Args, "--set", fmt.Sprintf("%s=%s", k, step.Set[k]))
+		cmd.Args = append(cmd.Args, "--set", fmt.Sprintf("%s=%v", k, step.Set[k]))
 	}
 
 	cmd.Stdout = m.Out

--- a/pkg/helm/install_test.go
+++ b/pkg/helm/install_test.go
@@ -41,7 +41,7 @@ func TestMixin_UnmarshalInstallStep(t *testing.T) {
 	assert.Equal(t, "stable/mysql", step.Chart)
 	assert.Equal(t, "0.10.2", step.Version)
 	assert.Equal(t, true, step.Replace)
-	assert.Equal(t, map[string]string{"mysqlDatabase": "mydb", "mysqlUser": "myuser"}, step.Set)
+	assert.Equal(t, map[string]interface{}{"mysqlDatabase": "mydb", "mysqlUser": "myuser"}, step.Set)
 }
 
 func TestMixin_Install(t *testing.T) {
@@ -49,9 +49,11 @@ func TestMixin_Install(t *testing.T) {
 	name := "MYRELEASE"
 	chart := "MYCHART"
 	version := "1.0.0"
-	setArgs := map[string]string{
-		"foo": "bar",
-		"baz": "qux",
+	setArgs := map[string]interface{}{
+		"foo":     "bar",
+		"baz":     "qux",
+		"number":  9,
+		"boolean": true,
 	}
 	values := []string{
 		"/tmp/val1.yaml",
@@ -60,7 +62,7 @@ func TestMixin_Install(t *testing.T) {
 
 	baseInstall := fmt.Sprintf(`helm install --name %s %s --namespace %s --version %s`, name, chart, namespace, version)
 	baseValues := `--values /tmp/val1.yaml --values /tmp/val2.yaml`
-	baseSetArgs := `--set baz=qux --set foo=bar`
+	baseSetArgs := `--set baz=qux --set boolean=true --set foo=bar --set number=9`
 
 	installTests := []InstallTest{
 		{

--- a/pkg/helm/schema/helm.json
+++ b/pkg/helm/schema/helm.json
@@ -29,10 +29,7 @@
               "type": "boolean"
             },
             "set": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              }
+              "type": "object"
             },
             "values": {
               "type": "array",
@@ -83,10 +80,7 @@
               "default": false
             },
             "set": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              }
+              "type": "object"
             },
             "values": {
               "type": "array",

--- a/pkg/helm/testdata/schema.json
+++ b/pkg/helm/testdata/schema.json
@@ -29,10 +29,7 @@
               "type": "boolean"
             },
             "set": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              }
+              "type": "object"
             },
             "values": {
               "type": "array",
@@ -83,10 +80,7 @@
               "default": false
             },
             "set": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              }
+              "type": "object"
             },
             "values": {
               "type": "array",

--- a/pkg/helm/upgrade.go
+++ b/pkg/helm/upgrade.go
@@ -22,15 +22,15 @@ type UpgradeStep struct {
 type UpgradeArguments struct {
 	Step `yaml:",inline"`
 
-	Namespace   string            `yaml:"namespace"`
-	Name        string            `yaml:"name"`
-	Chart       string            `yaml:"chart"`
-	Version     string            `yaml:"version"`
-	Set         map[string]string `yaml:"set"`
-	Values      []string          `yaml:"values"`
-	Wait        bool              `yaml:"wait"`
-	ResetValues bool              `yaml:"resetValues"`
-	ReuseValues bool              `yaml:"reuseValues"`
+	Namespace   string                 `yaml:"namespace"`
+	Name        string                 `yaml:"name"`
+	Chart       string                 `yaml:"chart"`
+	Version     string                 `yaml:"version"`
+	Set         map[string]interface{} `yaml:"set"`
+	Values      []string               `yaml:"values"`
+	Wait        bool                   `yaml:"wait"`
+	ResetValues bool                   `yaml:"resetValues"`
+	ReuseValues bool                   `yaml:"reuseValues"`
 }
 
 // Upgrade issues a helm upgrade command for a release using the provided UpgradeArguments
@@ -89,7 +89,7 @@ func (m *Mixin) Upgrade() error {
 	sort.Strings(setKeys)
 
 	for _, k := range setKeys {
-		cmd.Args = append(cmd.Args, "--set", fmt.Sprintf("%s=%s", k, step.Set[k]))
+		cmd.Args = append(cmd.Args, "--set", fmt.Sprintf("%s=%v", k, step.Set[k]))
 	}
 
 	cmd.Stdout = m.Out

--- a/pkg/helm/upgrade_test.go
+++ b/pkg/helm/upgrade_test.go
@@ -38,7 +38,7 @@ func TestMixin_UnmarshalUpgradeStep(t *testing.T) {
 	assert.True(t, step.Wait)
 	assert.True(t, step.ResetValues)
 	assert.True(t, step.ResetValues)
-	assert.Equal(t, map[string]string{"mysqlDatabase": "mydb", "mysqlUser": "myuser"}, step.Set)
+	assert.Equal(t, map[string]interface{}{"mysqlDatabase": "mydb", "mysqlUser": "myuser"}, step.Set)
 }
 
 func TestMixin_Upgrade(t *testing.T) {
@@ -46,9 +46,11 @@ func TestMixin_Upgrade(t *testing.T) {
 	name := "MYRELEASE"
 	chart := "MYCHART"
 	version := "1.0.0"
-	setArgs := map[string]string{
-		"foo": "bar",
-		"baz": "qux",
+	setArgs := map[string]interface{}{
+		"foo":     "bar",
+		"baz":     "qux",
+		"number":  9,
+		"boolean": true,
 	}
 	values := []string{
 		"/tmp/val1.yaml",
@@ -57,7 +59,7 @@ func TestMixin_Upgrade(t *testing.T) {
 
 	baseUpgrade := fmt.Sprintf(`helm upgrade %s %s --namespace %s --version %s`, name, chart, namespace, version)
 	baseValues := `--values /tmp/val1.yaml --values /tmp/val2.yaml`
-	baseSetArgs := `--set baz=qux --set foo=bar`
+	baseSetArgs := `--set baz=qux --set boolean=true --set foo=bar --set number=9`
 
 	upgradeTests := []UpgradeTest{
 		{


### PR DESCRIPTION
This PR adds support for generic-type values to be supplied on corresponding `helm {install,upgrade} ... --set key=value` commands.

Here I use `interface{}` as the type for these values, but unsure if this is too generic?  

Discovered this deficiency when installing the [azure-mysql-wordpress example bundle](https://github.com/deislabs/porter/blob/master/examples/azure-mysql-wordpress/porter.yaml), wherein some values intend to be set as integers (` externalDatabase.port: 3306`, etc.)

Not sure if my json schema amendments are correct 😉 