### PR TITLE
fix(schema): update set schema to allow for various types

### DIFF
--- a/pkg/helm/install_test.go
+++ b/pkg/helm/install_test.go
@@ -41,7 +41,8 @@ func TestMixin_UnmarshalInstallStep(t *testing.T) {
 	assert.Equal(t, "stable/mysql", step.Chart)
 	assert.Equal(t, "0.10.2", step.Version)
 	assert.Equal(t, true, step.Replace)
-	assert.Equal(t, map[string]string{"mysqlDatabase": "mydb", "mysqlUser": "myuser"}, step.Set)
+	assert.Equal(t, map[string]string{"mysqlDatabase": "mydb", "mysqlUser": "myuser",
+		"livenessProbe.initialDelaySeconds": "30", "persistence.enabled": "true"}, step.Set)
 }
 
 func TestMixin_Install(t *testing.T) {

--- a/pkg/helm/schema/helm.json
+++ b/pkg/helm/schema/helm.json
@@ -30,9 +30,7 @@
             },
             "set": {
               "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              }
+              "additionalProperties": true
             },
             "values": {
               "type": "array",
@@ -84,9 +82,7 @@
             },
             "set": {
               "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              }
+              "additionalProperties": true
             },
             "values": {
               "type": "array",

--- a/pkg/helm/testdata/install-input.yaml
+++ b/pkg/helm/testdata/install-input.yaml
@@ -8,6 +8,8 @@ install:
     set:
       mysqlDatabase: mydb
       mysqlUser: myuser
+      livenessProbe.initialDelaySeconds: 30
+      persistence.enabled: true
     outputs:
       - name: mysql-root-password
         secret: porter-ci-mysql

--- a/pkg/helm/testdata/schema.json
+++ b/pkg/helm/testdata/schema.json
@@ -30,9 +30,7 @@
             },
             "set": {
               "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              }
+              "additionalProperties": true
             },
             "values": {
               "type": "array",
@@ -84,9 +82,7 @@
             },
             "set": {
               "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              }
+              "additionalProperties": true
             },
             "values": {
               "type": "array",

--- a/pkg/helm/testdata/upgrade-input.yaml
+++ b/pkg/helm/testdata/upgrade-input.yaml
@@ -10,6 +10,8 @@ upgrade:
     set:
       mysqlDatabase: mydb
       mysqlUser: myuser
+      livenessProbe.initialDelaySeconds: 30
+      persistence.enabled: true
     outputs:
       - name: mysql-root-password
         secret: porter-ci-mysql

--- a/pkg/helm/upgrade_test.go
+++ b/pkg/helm/upgrade_test.go
@@ -38,7 +38,8 @@ func TestMixin_UnmarshalUpgradeStep(t *testing.T) {
 	assert.True(t, step.Wait)
 	assert.True(t, step.ResetValues)
 	assert.True(t, step.ResetValues)
-	assert.Equal(t, map[string]string{"mysqlDatabase": "mydb", "mysqlUser": "myuser"}, step.Set)
+	assert.Equal(t, map[string]string{"mysqlDatabase": "mydb", "mysqlUser": "myuser",
+		"livenessProbe.initialDelaySeconds": "30", "persistence.enabled": "true"}, step.Set)
 }
 
 func TestMixin_Upgrade(t *testing.T) {


### PR DESCRIPTION
Updates the `set` portion of this mixin's schema to allow for various types.

Credit to @carolynvs for the change/fix.  See https://github.com/deislabs/porter-helm/pull/28#issuecomment-478072977 

Tested via `make test-cli` from https://github.com/deislabs/porter/pull/246