### PR TITLE
Do not publish extra runtime binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,12 @@ LDFLAGS = -w -X $(PKG)/pkg.Version=$(VERSION) -X $(PKG)/pkg.Commit=$(COMMIT)
 XBUILD = CGO_ENABLED=0 go build -a -tags netgo -ldflags '$(LDFLAGS)'
 BINDIR = bin/mixins/$(MIXIN)
 
-CLIENT_PLATFORM = $(shell go env GOOS)
-CLIENT_ARCH = $(shell go env GOARCH)
+CLIENT_PLATFORM ?= $(shell go env GOOS)
+CLIENT_ARCH ?= $(shell go env GOARCH)
 RUNTIME_PLATFORM ?= linux
 RUNTIME_ARCH ?= amd64
-SUPPORTED_CLIENT_PLATFORMS = linux darwin windows
-SUPPORTED_CLIENT_ARCHES = amd64 386
+SUPPORTED_PLATFORMS = linux darwin windows
+SUPPORTED_ARCHES = amd64
 
 ifeq ($(CLIENT_PLATFORM),windows)
 FILE_EXT=.exe
@@ -29,6 +29,7 @@ endif
 
 REGISTRY ?= $(USER)
 
+.PHONY: build
 build: build-client build-runtime
 
 build-runtime: generate
@@ -48,15 +49,13 @@ ifndef HAS_PACKR2
 	go get -u github.com/gobuffalo/packr/v2/packr2
 endif
 
-xbuild-all: xbuild-runtime $(addprefix xbuild-for-,$(SUPPORTED_CLIENT_PLATFORMS))
+xbuild-all:
+	$(foreach OS, $(SUPPORTED_PLATFORMS), \
+		$(foreach ARCH, $(SUPPORTED_ARCHES), \
+				$(MAKE) $(MAKE_OPTS) CLIENT_PLATFORM=$(OS) CLIENT_ARCH=$(ARCH) MIXIN=$(MIXIN) xbuild; \
+		))
 
-xbuild-for-%:
-	$(MAKE) CLIENT_PLATFORM=$* xbuild-client
-
-xbuild-runtime:
-	GOARCH=$(RUNTIME_ARCH) GOOS=$(RUNTIME_PLATFORM) $(XBUILD) -o $(BINDIR)/$(VERSION)/$(MIXIN)-runtime-$(RUNTIME_PLATFORM)-$(RUNTIME_ARCH)$(FILE_EXT) ./cmd/$(MIXIN)
-
-xbuild-client: $(BINDIR)/$(VERSION)/$(MIXIN)-$(CLIENT_PLATFORM)-$(CLIENT_ARCH)$(FILE_EXT)
+xbuild: $(BINDIR)/$(VERSION)/$(MIXIN)-$(CLIENT_PLATFORM)-$(CLIENT_ARCH)$(FILE_EXT)
 $(BINDIR)/$(VERSION)/$(MIXIN)-$(CLIENT_PLATFORM)-$(CLIENT_ARCH)$(FILE_EXT):
 	mkdir -p $(dir $@)
 	GOOS=$(CLIENT_PLATFORM) GOARCH=$(CLIENT_ARCH) $(XBUILD) -o $@ ./cmd/$(MIXIN)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,7 +42,12 @@ steps:
   displayName: 'Unit Test'
 
 - script: |
-    AZURE_STORAGE_CONNECTION_STRING=$(AZURE_STORAGE_CONNECTION_STRING) make xbuild-all publish
+    make xbuild-all
+  workingDirectory: '$(modulePath)'
+  displayName: 'Cross Compile'
+
+- script: |
+    AZURE_STORAGE_CONNECTION_STRING=$(AZURE_STORAGE_CONNECTION_STRING) make publish
   workingDirectory: '$(modulePath)'
   displayName: 'Publish'
   condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))


### PR DESCRIPTION
This removes the unnecessary `helm-runtime-linux-amd64` binary from the build matrix.

While I was in there, I standardized the Makefile with some of the other changes that we had from the porter **mixin.mk` so it's easier to read.