### PR TITLE
Do not validate against json schema at runtime

### DIFF
--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -40,10 +40,6 @@ func (m *Mixin) getPayloadData() ([]byte, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "could not read the payload from STDIN")
 	}
-	err = m.ValidatePayload(data)
-	if err != nil {
-		return nil, err
-	}
 	return data, nil
 }
 


### PR DESCRIPTION
We don't want a small validation problem to prevent a bundle from running which is why we aren't running the validation at runtime.

See https://github.com/deislabs/porter-terraform/pull/19#discussion_r317629816 for context.

We plan to validate the yaml at build time in https://github.com/deislabs/porter/issues/532.