### PR TITLE
feat(upgrade.go): add --install to helm upgrade invocation

### DIFF
--- a/pkg/helm/upgrade.go
+++ b/pkg/helm/upgrade.go
@@ -60,7 +60,7 @@ func (m *Mixin) Upgrade() error {
 		return err
 	}
 
-	cmd := m.NewCommand("helm", "upgrade", step.Name, step.Chart)
+	cmd := m.NewCommand("helm", "upgrade", "--install", step.Name, step.Chart)
 
 	if step.Namespace != "" {
 		cmd.Args = append(cmd.Args, "--namespace", step.Namespace)

--- a/pkg/helm/upgrade_test.go
+++ b/pkg/helm/upgrade_test.go
@@ -56,7 +56,7 @@ func TestMixin_Upgrade(t *testing.T) {
 		"/tmp/val2.yaml",
 	}
 
-	baseUpgrade := fmt.Sprintf(`helm upgrade %s %s --namespace %s --version %s`, name, chart, namespace, version)
+	baseUpgrade := fmt.Sprintf(`helm upgrade --install %s %s --namespace %s --version %s`, name, chart, namespace, version)
 	baseValues := `--values /tmp/val1.yaml --values /tmp/val2.yaml`
 	baseSetArgs := `--set baz=qux --set foo=bar`
 


### PR DESCRIPTION
Adds `--install` to the `helm upgrade ...` command as invoked by an upgrade step using this mixin, to create a release if for some reason it didn't yet pre-exist.

Closes https://github.com/deislabs/porter-helm/issues/45