### PR TITLE
Standardize repository window dressing

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to project admins via email - Carolyn Van Slyck (`me@carolynvanslyck.com`)
+- or via direct message in [Slack] to Carolyn Van Slyck (`@carolynvs`) or Jeremy Rickard (`@Jeremy Rickard`). 
+All complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -72,3 +72,4 @@ This Code of Conduct is adapted from the [Contributor Covenant][homepage], versi
 available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
 
 [homepage]: https://www.contributor-covenant.org
+[slack]: https://porter.sh/community/#slack

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contributing Guide
+
+This is part of the [Porter][porter] project. If you are a new contributor,
+check out our [New Contributor Guide][new-contrib]. The Porter [Contributing
+Guide][contrib] also has lots of information about how to interact with the
+project.
+
+[porter]: https://github.com/deislabs/porter
+[new-contrib]: https://porter.sh/contribute
+[contrib]: https://github.com/deislabs/porter/blob/master/CONTRIBUTING.md
+
+---
+
+* [Initial setup](#initial-setup)
+* [Makefile explained](#makefile-explained)
+
+---
+
+# Initial setup
+
+You need to have [porter installed](https://porter.sh/install) first. Then run
+`make build install`. This will build and install the mixin into your porter
+home directory.
+
+## Makefile explained
+
+Here are the most common Makefile tasks
+
+* `build` builds both the runtime and client.
+* `install` installs the mixin into **~/.porter/mixins**.
+* `test-unit` runs the unit tests.
+* `clean-packr` removes extra packr files that were a side-effect of the build.
+  Normally this is run automatically but if you run into issues with packr and
+  dep, run this command.
+* `dep-ensure` runs dep ensure for you while taking care of packr properly. Use
+  this if your PRs are often failing on `verify-vendor` because of packr. This
+  can be avoided entirely if you use `make build`.
+* `verify-vendor` cleans up packr generated files and verifies that dep's Gopkg.lock 
+   and vendor/ are up-to-date. Use this makefile target instead of running 
+   dep check manually.

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -879,7 +879,6 @@
     "github.com/deislabs/porter/pkg/test",
     "github.com/ghodss/yaml",
     "github.com/gobuffalo/packr/v2",
-    "github.com/gobuffalo/packr/v2/file/resolver",
     "github.com/hashicorp/go-multierror",
     "github.com/mholt/archiver",
     "github.com/pkg/errors",

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ endif
 REGISTRY ?= $(USER)
 
 .PHONY: build
-build: build-client build-runtime
+build: build-client build-runtime clean-packr
 
 build-runtime: generate
 	mkdir -p $(BINDIR)
@@ -54,11 +54,27 @@ xbuild-all:
 		$(foreach ARCH, $(SUPPORTED_ARCHES), \
 				$(MAKE) $(MAKE_OPTS) CLIENT_PLATFORM=$(OS) CLIENT_ARCH=$(ARCH) MIXIN=$(MIXIN) xbuild; \
 		))
+	$(MAKE) clean-packr
 
 xbuild: $(BINDIR)/$(VERSION)/$(MIXIN)-$(CLIENT_PLATFORM)-$(CLIENT_ARCH)$(FILE_EXT)
 $(BINDIR)/$(VERSION)/$(MIXIN)-$(CLIENT_PLATFORM)-$(CLIENT_ARCH)$(FILE_EXT):
 	mkdir -p $(dir $@)
 	GOOS=$(CLIENT_PLATFORM) GOARCH=$(CLIENT_ARCH) $(XBUILD) -o $@ ./cmd/$(MIXIN)
+
+verify: verify-vendor
+
+verify-vendor: clean-packr dep
+	@dep check || printf '\nRun "make dep-ensure" to fix this error\n\n'
+
+dep-ensure: clean-packr
+	dep ensure
+
+HAS_DEP := $(shell command -v dep)
+dep:
+ifndef HAS_DEP
+	curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+endif
+	dep version
 
 test: test-unit
 
@@ -89,5 +105,8 @@ install:
 	install $(BINDIR)/$(MIXIN)$(FILE_EXT) $(PORTER_HOME)/mixins/$(MIXIN)/$(MIXIN)$(FILE_EXT)
 	install $(BINDIR)/$(MIXIN)-runtime$(FILE_EXT) $(PORTER_HOME)/mixins/$(MIXIN)/$(MIXIN)-runtime$(FILE_EXT)
 
-clean:
+clean: clean-packr
 	-rm -fr bin/
+
+clean-packr: packr2
+	cd pkg/helm && packr2 clean

--- a/README.md
+++ b/README.md
@@ -1,3 +1,129 @@
 # Helm Mixin for Porter
 
-This is a Helm mixin for [Porter](https://github.com/deislabs/porter).
+<img src="https://porter.sh/images/mixins/helm.svg" align="right" width="150px"/>
+
+This is a Helm mixin for [Porter](https://github.com/deislabs/porter). It executes the
+appropriate helm command based on which action it is included within: `install`,
+`upgrade`, or `delete`.
+
+### Install or Upgrade
+
+```
+porter mixin install helm
+```
+
+### Mixin Syntax
+
+Install
+
+```yaml
+install:
+- helm:
+    description: "Description of the command"
+    name: RELEASE_NAME
+    chart: STABLE_CHART_NAME
+    version: CHART_VERSION
+    namespace: NAMESPACE
+    replace: BOOL
+    devel: BOOL
+    wait: BOOL # default true
+    set:
+      VAR1: VALUE1
+      VAR2: VALUE2
+```
+
+Upgrade
+
+```yaml
+install:
+- helm:
+    description: "Description of the command"
+    name: RELEASE_NAME
+    chart: STABLE_CHART_NAME
+    version: CHART_VERSION
+    namespace: NAMESPACE
+    resetValues: BOOL
+    reuseValues: BOOL
+    wait: BOOL # default true
+    set:
+      VAR1: VALUE1
+      VAR2: VALUE2
+```
+
+Uninstall
+
+```yaml
+uninstall:
+- helm:
+    description: "Description of command"
+    purge: BOOL
+    releases:
+      - RELEASE_NAME1
+      - RELASE_NAME2
+```
+
+#### Outputs
+
+The mixin supports saving secrets from Kuberentes as outputs.
+
+```yaml
+outputs:
+    - name: NAME
+      secret: SECRET_NAME
+      key: SECRET_KEY
+```
+
+### Examples
+
+Install
+
+```yaml
+install:
+- helm:
+    description: "Install MySQL"
+    name: mydb
+    chart: stable/mysql
+    version: 0.10.2
+    namespace: mydb
+    replace: true
+    set:
+      mysqlDatabase: wordpress
+      mysqlUser: wordpress
+    outputs:
+      - name: mysql-root-password
+        secret: mydb-mysql
+        key: mysql-root-password
+      - name: mysql-password
+        secret: mydb-mysql
+        key: mysql-password
+```
+
+Upgrade
+
+```yaml
+upgrade:
+- helm:
+    description: "Upgrade MySQL"
+    name: porter-ci-mysql
+    chart: stable/mysql
+    version: 0.10.2
+    wait: true
+    resetValues: true
+    reuseValues: false
+    set:
+      mysqlDatabase: mydb
+      mysqlUser: myuser
+      livenessProbe.initialDelaySeconds: 30
+      persistence.enabled: true
+```
+
+Uninstall
+
+```yaml
+uninstall:
+- helm:
+    description: "Uninstall MySQL"
+    purge: true
+    releases:
+      - mydb
+```

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -1,0 +1,17 @@
+# Reviewing Guide
+
+This is part of the [Porter][porter] project and follows the Porter [Reviewing
+Guide][review].
+
+[porter]: https://github.com/deislabs/porter
+[review]: https://github.com/deislabs/porter/blob/master/REVIEWING.md
+
+## Cut a release
+
+🧀💨
+
+All mixins follow the same process for [cutting a release][release]. There is an additional step after tagging the release. When any documenation on the readme is changed, update the matching documenation page for the mixin on the porter website:
+
+https://github.com/deislabs/porter/tree/master/docs/content/mixins
+
+[release]: https://github.com/deislabs/porter/blob/master/REVIEWING.md#cut-a-release


### PR DESCRIPTION
Update all the supporting repository pages: readme, CoC, contributing, etc to match Porter and reference Porter where we can.

This is a part of https://github.com/deislabs/porter/issues/675.