### PR TITLE
chore(build.go): bump helm client to v2.15.2

### DIFF
--- a/pkg/helm/build.go
+++ b/pkg/helm/build.go
@@ -5,7 +5,7 @@ import (
 )
 
 // These values may be referenced elsewhere (init.go), hence consts
-const helmClientVersion string = "v2.14.3"
+const helmClientVersion string = "v2.15.2"
 const helmArchiveTmpl string = "helm-%s-linux-amd64.tar.gz"
 const helmDownloadURLTmpl string = "https://get.helm.sh/%s"
 

--- a/pkg/helm/build_test.go
+++ b/pkg/helm/build_test.go
@@ -15,7 +15,7 @@ func TestMixin_Build(t *testing.T) {
 
 	wantOutput := `RUN apt-get update && \
  apt-get install -y curl && \
- curl -o helm.tgz https://get.helm.sh/helm-v2.14.3-linux-amd64.tar.gz && \
+ curl -o helm.tgz https://get.helm.sh/helm-v2.15.2-linux-amd64.tar.gz && \
  tar -xzf helm.tgz && \
  mv linux-amd64/helm /usr/local/bin && \
  rm helm.tgz

--- a/pkg/helm/init_test.go
+++ b/pkg/helm/init_test.go
@@ -62,7 +62,7 @@ func TestMixin_Init_MismatchedVersion(t *testing.T) {
 	require.NoError(t, err)
 
 	gotOutput := h.TestContext.GetOutput()
-	wantOutput := "Tiller version (mismatchedVersion) does not match client version (v2.14.3); downloading a compatible client.\n"
+	wantOutput := "Tiller version (mismatchedVersion) does not match client version (v2.15.2); downloading a compatible client.\n"
 	require.Equal(t, wantOutput, gotOutput)
 }
 
@@ -82,6 +82,6 @@ func TestMixin_Init_FailedClientInstall(t *testing.T) {
 	require.EqualError(t, err, "unable to install a compatible helm client: failed to install helm client")
 
 	gotOutput := h.TestContext.GetOutput()
-	wantOutput := "Tiller version (mismatchedVersion) does not match client version (v2.14.3); downloading a compatible client.\n"
+	wantOutput := "Tiller version (mismatchedVersion) does not match client version (v2.15.2); downloading a compatible client.\n"
 	require.Equal(t, wantOutput, gotOutput)
 }


### PR DESCRIPTION
Bumps the default helm client version to the next major release (or, last stable variant thereof), [v2.15.2](https://github.com/helm/helm/releases/tag/v2.15.2), which came with some API updates for compatibility with more recent versions of k8s.

Fixes the issue mentioned in https://github.com/deislabs/porter-helm/issues/53#issue-551431835.

Closes https://github.com/deislabs/porter-helm/issues/53