### PR TITLE
feat(build.go): restrict to client version of v2.x.x

### DIFF
--- a/pkg/helm/build_test.go
+++ b/pkg/helm/build_test.go
@@ -61,7 +61,7 @@ RUN apt-get update && \
 
 	t.Run("build with a defined helm client version", func(t *testing.T) {
 
-		b, err := ioutil.ReadFile("testdata/build-input-with-version.yaml")
+		b, err := ioutil.ReadFile("testdata/build-input-with-supported-client-version.yaml")
 		require.NoError(t, err)
 
 		m := NewTestMixin(t)
@@ -72,5 +72,29 @@ RUN apt-get update && \
 		wantOutput := fmt.Sprintf(buildOutput, m.HelmClientVersion)
 		gotOutput := m.TestContext.GetOutput()
 		assert.Equal(t, wantOutput, gotOutput)
+	})
+
+	t.Run("build with a defined helm client version that does not meet the semver constraint", func(t *testing.T) {
+
+		b, err := ioutil.ReadFile("testdata/build-input-with-unsupported-client-version.yaml")
+		require.NoError(t, err)
+
+		m := NewTestMixin(t)
+		m.Debug = false
+		m.In = bytes.NewReader(b)
+		err = m.Build()
+		require.EqualError(t, err, `supplied clientVersion "v3.2.1" does not meet semver constraint "^v2.x"`)
+	})
+
+	t.Run("build with a defined helm client version that does not parse as valid semver", func(t *testing.T) {
+
+		b, err := ioutil.ReadFile("testdata/build-input-with-invalid-client-version.yaml")
+		require.NoError(t, err)
+
+		m := NewTestMixin(t)
+		m.Debug = false
+		m.In = bytes.NewReader(b)
+		err = m.Build()
+		require.EqualError(t, err, `supplied client version "v3.2.1.0" cannot be parsed as semver: Invalid Semantic Version`)
 	})
 }

--- a/pkg/helm/testdata/build-input-with-invalid-client-version.yaml
+++ b/pkg/helm/testdata/build-input-with-invalid-client-version.yaml
@@ -1,0 +1,8 @@
+config:
+  clientVersion: v3.2.1.0
+install:
+  - helm:
+      description: "Install MySQL"
+      name: porter-ci-mysql
+      chart: stable/mysql
+      version: 0.10.2

--- a/pkg/helm/testdata/build-input-with-supported-client-version.yaml
+++ b/pkg/helm/testdata/build-input-with-supported-client-version.yaml
@@ -1,5 +1,5 @@
 config:
-  version: v2.16.1
+  clientVersion: v2.16.1
 install:
   - helm:
       description: "Install MySQL"

--- a/pkg/helm/testdata/build-input-with-unsupported-client-version.yaml
+++ b/pkg/helm/testdata/build-input-with-unsupported-client-version.yaml
@@ -1,0 +1,8 @@
+config:
+  clientVersion: v3.2.1
+install:
+  - helm:
+      description: "Install MySQL"
+      name: porter-ci-mysql
+      chart: stable/mysql
+      version: 0.10.2


### PR DESCRIPTION
* adds functionality to verify the client version supplied via mixin config satisfies semver constraints

Depends on https://github.com/deislabs/porter/pull/989 for build error to actually stop build.

Closes https://github.com/deislabs/porter-helm/issues/67