### PR TITLE
Fix version match

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ GO = GO111MODULE=on go
 PORTER_HOME ?= $(HOME)/.porter
 
 COMMIT ?= $(shell git rev-parse --short HEAD)
-VERSION ?= $(shell git describe --tags 2> /dev/null || echo v0)
-PERMALINK ?= $(shell git describe --tags --exact-match &> /dev/null && echo latest || echo canary)
+VERSION ?= $(shell git describe --tags --match v* 2> /dev/null || echo v0)
+PERMALINK ?= $(shell git describe --tags --exact-match --match v* &> /dev/null && echo latest || echo canary)
 
 LDFLAGS = -w -X $(PKG)/pkg.Version=$(VERSION) -X $(PKG)/pkg.Commit=$(COMMIT)
 XBUILD = CGO_ENABLED=0 $(GO) build -a -tags netgo -ldflags '$(LDFLAGS)'


### PR DESCRIPTION
I need to go back and update the makefiles of the mixins to deal with tags better. I re-kicked a build that had already gotten to the point of pushing the latest tag and that messed up which tag was selected when it was repeated. 

Since I just want to get one release out and archive this repo, I'm hoping this small fix is better than refactoring the makefile.